### PR TITLE
Add explicit yes/no checkboxes

### DIFF
--- a/src/components/formulario.tsx
+++ b/src/components/formulario.tsx
@@ -10,6 +10,7 @@ import {
   Divider,
   Paper,
   FormControlLabel,
+  FormGroup,
   Checkbox,
   Backdrop,
   Fade,
@@ -170,16 +171,31 @@ export default function FormularioDocumint() {
                           ))}
                         </TextField>
                       ) : type === "checkbox" ? (
-                        <FormControlLabel
-                          control={
-                            <Checkbox
-                              {...field}
-                              checked={Boolean(field.value)}
-                              required={required || false}
+                        <Box>
+                          <Typography>{label}</Typography>
+                          <FormGroup row>
+                            <FormControlLabel
+                              control={
+                                <Checkbox
+                                  checked={field.value === true}
+                                  onChange={() => field.onChange(true)}
+                                  required={required || false}
+                                />
+                              }
+                              label="Si"
                             />
-                          }
-                          label={label}
-                        />
+                            <FormControlLabel
+                              control={
+                                <Checkbox
+                                  checked={field.value === false}
+                                  onChange={() => field.onChange(false)}
+                                  required={required || false}
+                                />
+                              }
+                              label="No"
+                            />
+                          </FormGroup>
+                        </Box>
                       ) : type === "textarea" ? (
                         <TextField
                           {...field}


### PR DESCRIPTION
## Summary
- add `FormGroup` import
- show two checkboxes labelled "Si" and "No" for boolean form inputs

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: Cannot find module '@mui/material')*

------
https://chatgpt.com/codex/tasks/task_e_6859cf889dc08325b9a9ddd1e3576610